### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Python CI
 
 on:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
-permissions:
-  contents: read
 name: Python CI
 
+permissions:
+  contents: read
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/ileodo/moneywiz-api/security/code-scanning/1](https://github.com/ileodo/moneywiz-api/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, runs linters, tests, and uploads artifacts (but does not push code, create issues, or modify pull requests), the minimal required permission is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs unless overridden. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
