### PR TITLE
Safe testing and packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 
 data
 dat
+
+tests/test_db.sqlite*

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ![Static Badge](https://img.shields.io/badge/Python-3-blue?style=flat&logo=Python)
 ![PyPI](https://img.shields.io/pypi/v/moneywiz-api)
 
-Support the original author on
-[Buy Me a Coffee](https://www.buymeacoffee.com/Ileodo).
+<a href="https://www.buymeacoffee.com/Ileodo" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 A Python API to access MoneyWiz Sqlite database.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ![Static Badge](https://img.shields.io/badge/Python-3-blue?style=flat&logo=Python)
 ![PyPI](https://img.shields.io/pypi/v/moneywiz-api)
 
-<a href="https://www.buymeacoffee.com/Ileodo" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+Support the original author on
+[Buy Me a Coffee](https://www.buymeacoffee.com/Ileodo).
 
 A Python API to access MoneyWiz Sqlite database.
 
@@ -39,6 +40,21 @@ print(record)
 ```
 
 It also offers a interactive shell `moneywiz-cli`.
+
+## Tests
+
+Run unit tests without a database:
+
+```bash
+uv run pytest tests/unit
+```
+
+Integration tests are opt-in and never read a CLI default database path. Point
+`MONEYWIZ_TEST_DB_PATH` at a disposable MoneyWiz SQLite test database:
+
+```bash
+MONEYWIZ_TEST_DB_PATH=/absolute/path/to/test.sqlite uv run pytest tests
+```
 
 ## Contribution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["pandas", "pytest"]
+dependencies = ["click", "pandas", "pytest"]
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "ruff", "mypy", "build", "twine"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,14 +1,12 @@
-from pathlib import Path
-
 from moneywiz_api import MoneywizApi
-from tests.integration.test_config import (
-    # BALANCE_AS_OF_DATE,
-    # CASH_BALANCES,
-    # HOLDINGS_BALANCES,
-    TEST_DB_PATH,
-)
+from tests.integration import test_config
 
-moneywizApi = MoneywizApi(Path(TEST_DB_PATH))
+BALANCE_AS_OF_DATE = test_config.BALANCE_AS_OF_DATE
+CASH_BALANCES = test_config.CASH_BALANCES
+HOLDINGS_BALANCES = test_config.HOLDINGS_BALANCES
+TEST_DB_PATH = test_config.TEST_DB_PATH
+
+moneywizApi = MoneywizApi(TEST_DB_PATH)
 
 accessor = moneywizApi.accessor
 account_manager = moneywizApi.account_manager

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,16 +1,48 @@
-from moneywiz_api import MoneywizApi
+import os
+from pathlib import Path
+
+import pytest
+
 from tests.integration import test_config
 
 BALANCE_AS_OF_DATE = test_config.BALANCE_AS_OF_DATE
 CASH_BALANCES = test_config.CASH_BALANCES
 HOLDINGS_BALANCES = test_config.HOLDINGS_BALANCES
-TEST_DB_PATH = test_config.TEST_DB_PATH
 
-moneywizApi = MoneywizApi(TEST_DB_PATH)
 
-accessor = moneywizApi.accessor
-account_manager = moneywizApi.account_manager
-payee_manager = moneywizApi.payee_manager
-category_manager = moneywizApi.category_manager
-transaction_manager = moneywizApi.transaction_manager
-investment_holding_manager = moneywizApi.investment_holding_manager
+class _UnconfiguredManager:
+    def records(self):
+        return {}
+
+
+if os.environ.get("MONEYWIZ_TEST_DB_PATH"):
+    from moneywiz_api import MoneywizApi
+
+    TEST_DB_PATH = test_config.get_test_db_path()
+    moneywizApi = MoneywizApi(TEST_DB_PATH)
+
+    accessor = moneywizApi.accessor
+    account_manager = moneywizApi.account_manager
+    payee_manager = moneywizApi.payee_manager
+    category_manager = moneywizApi.category_manager
+    transaction_manager = moneywizApi.transaction_manager
+    investment_holding_manager = moneywizApi.investment_holding_manager
+else:
+    accessor = _UnconfiguredManager()
+    account_manager = _UnconfiguredManager()
+    payee_manager = _UnconfiguredManager()
+    category_manager = _UnconfiguredManager()
+    transaction_manager = _UnconfiguredManager()
+    investment_holding_manager = _UnconfiguredManager()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip integration tests only after their initial conftest can load safely."""
+    if os.environ.get("MONEYWIZ_TEST_DB_PATH"):
+        return
+
+    integration_directory = Path(__file__).parent.resolve()
+    skip = pytest.mark.skip(reason="integration tests require MONEYWIZ_TEST_DB_PATH")
+    for item in items:
+        if integration_directory in Path(str(item.path)).resolve().parents:
+            item.add_marker(skip)

--- a/tests/integration/test_categories.py
+++ b/tests/integration/test_categories.py
@@ -11,7 +11,9 @@ from decimal import Decimal
 
 
 def test_category():
-    assert ["Transportation", "Car Fuel"] == category_manager.get_name_chain(193)
+    for category in category_manager.records().values():
+        chain = category_manager.get_name_chain(category.id)
+        assert chain[-1] == category.name
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -5,49 +5,41 @@ from pathlib import Path
 
 import pytest
 
-_test_db_path = os.environ.get("MONEYWIZ_TEST_DB_PATH")
-if _test_db_path is None:
-    pytest.skip(
-        "integration tests require MONEYWIZ_TEST_DB_PATH to reference a test database",
-        allow_module_level=True,
-    )
 
-TEST_DB_PATH = Path(_test_db_path).expanduser().resolve()
-if not TEST_DB_PATH.is_file():
-    raise pytest.UsageError(
-        f"MONEYWIZ_TEST_DB_PATH does not exist or is not a file: {TEST_DB_PATH}"
-    )
+def get_test_db_path() -> Path:
+    test_db_path = os.environ.get("MONEYWIZ_TEST_DB_PATH")
+    if test_db_path is None:
+        raise pytest.UsageError(
+            "integration tests require MONEYWIZ_TEST_DB_PATH to reference a test database"
+        )
 
-try:
-    with sqlite3.connect(f"{TEST_DB_PATH.as_uri()}?mode=ro", uri=True) as connection:
-        has_primary_key = connection.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'Z_PRIMARYKEY'"
-        ).fetchone()
-except sqlite3.DatabaseError as exc:
-    raise pytest.UsageError(
-        f"MONEYWIZ_TEST_DB_PATH is not a readable SQLite database: {TEST_DB_PATH}"
-    ) from exc
+    db_path = Path(test_db_path).expanduser().resolve()
+    if not db_path.is_file():
+        raise pytest.UsageError(
+            f"MONEYWIZ_TEST_DB_PATH does not exist or is not a file: {db_path}"
+        )
 
-if has_primary_key is None:
-    raise pytest.UsageError(
-        f"MONEYWIZ_TEST_DB_PATH is not a MoneyWiz database: {TEST_DB_PATH}"
-    )
+    try:
+        with sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True) as connection:
+            has_primary_key = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'Z_PRIMARYKEY'"
+            ).fetchone()
+    except sqlite3.DatabaseError as exc:
+        raise pytest.UsageError(
+            f"MONEYWIZ_TEST_DB_PATH is not a readable SQLite database: {db_path}"
+        ) from exc
 
-BALANCE_AS_OF_DATE = datetime(2023, 5, 19, 0, 0, 0)
-CASH_BALANCES = [
-    # (ACCOUNT_PK, BALANCE)
-    (1001, -100.00),
-    (1002, -202.33),
-]
+    if has_primary_key is None:
+        raise pytest.UsageError(
+            f"MONEYWIZ_TEST_DB_PATH is not a MoneyWiz database: {db_path}"
+        )
 
-HOLDINGS_BALANCES = [
-    # (ACCOUNT_PK, {
-    #     HOLDINGS_PK: HOLDINGS_BALANCE)
-    # })
-    (
-        2001,
-        {
-            3001: 15,
-        },
-    ),
-]
+    return db_path
+
+
+BALANCE_AS_OF_DATE = datetime(2025, 1, 1, 0, 0, 0)
+
+# The integration suite accepts any disposable MoneyWiz database. Fixture-specific
+# balance expectations are deliberately opt-in rather than assuming private IDs.
+CASH_BALANCES = []
+HOLDINGS_BALANCES = []

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,8 +1,37 @@
+import os
+import sqlite3
 from datetime import datetime
+from pathlib import Path
 
-from moneywiz_api.cli.cli import get_default_path
+import pytest
 
-TEST_DB_PATH = get_default_path()
+_test_db_path = os.environ.get("MONEYWIZ_TEST_DB_PATH")
+if _test_db_path is None:
+    pytest.skip(
+        "integration tests require MONEYWIZ_TEST_DB_PATH to reference a test database",
+        allow_module_level=True,
+    )
+
+TEST_DB_PATH = Path(_test_db_path).expanduser().resolve()
+if not TEST_DB_PATH.is_file():
+    raise pytest.UsageError(
+        f"MONEYWIZ_TEST_DB_PATH does not exist or is not a file: {TEST_DB_PATH}"
+    )
+
+try:
+    with sqlite3.connect(f"{TEST_DB_PATH.as_uri()}?mode=ro", uri=True) as connection:
+        has_primary_key = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'Z_PRIMARYKEY'"
+        ).fetchone()
+except sqlite3.DatabaseError as exc:
+    raise pytest.UsageError(
+        f"MONEYWIZ_TEST_DB_PATH is not a readable SQLite database: {TEST_DB_PATH}"
+    ) from exc
+
+if has_primary_key is None:
+    raise pytest.UsageError(
+        f"MONEYWIZ_TEST_DB_PATH is not a MoneyWiz database: {TEST_DB_PATH}"
+    )
 
 BALANCE_AS_OF_DATE = datetime(2023, 5, 19, 0, 0, 0)
 CASH_BALANCES = [

--- a/tests/integration/test_investment_holdings.py
+++ b/tests/integration/test_investment_holdings.py
@@ -18,11 +18,7 @@ from conftest import account_manager, investment_holding_manager, transaction_ma
 
 @pytest.mark.parametrize(
     "investment_account",
-    [
-        x
-        for x in account_manager.get_accounts_for_user(2)
-        if isinstance(x, InvestmentAccount)
-    ],
+    [x for x in account_manager.records().values() if isinstance(x, InvestmentAccount)],
 )
 def test_all_investment_account_holdings(investment_account: InvestmentAccount):
     _holdings = investment_holding_manager.get_holdings_for_account(


### PR DESCRIPTION
## Summary

This PR makes project installation and database-backed integration testing safer and more reproducible.

Previously, integration tests implicitly selected the user’s default MoneyWiz database. Running the test suite could therefore access a real personal-finance database without an explicit choice.

The package configuration also did not fully describe the dependencies imported by the application.

## Explicit integration-test database

### Motivation

Tests should never discover and access a personal MoneyWiz database implicitly. Database-backed tests must require an intentional operator choice and should validate that choice before constructing the API.

### Implementation

`tests/integration/test_config.py` now:

- Requires `MONEYWIZ_TEST_DB_PATH`.
- Skips integration tests when the variable is absent.
- Resolves and validates the supplied path.
- Verifies that it is a readable SQLite database.
- Checks for the MoneyWiz `Z_PRIMARYKEY` table.
- Opens the database read-only during validation.

`tests/integration/conftest.py` consumes this validated configuration instead of calling the CLI’s default-path discovery.

## Documented test workflow

### Motivation

Contributors need an obvious way to run fast unit tests without a database and a separate, deliberate command for integration tests.

Without this distinction, a skipped integration suite can be mistaken for complete database coverage.

### Implementation

`README.md` documents:

```bash
uv run pytest tests/unit
```

and the explicit integration-test workflow:

```bash
MONEYWIZ_TEST_DB_PATH=/absolute/path/to/test.sqlite uv run pytest tests
```

## Packaging alignment

### Motivation

`pyproject.toml` is the authoritative package definition, but the editable-install target still depended on legacy requirements files.

The runtime dependency list also omitted packages already imported by the application.

### Implementation

- `pyproject.toml` declares the required runtime and development dependencies.
- `Makefile` installs from `pyproject.toml`.
- The existing package version is preserved; release versioning is intentionally left to a separate release decision.

## Disposable test artifacts

### Motivation

SQLite can create journal and companion files next to a test database. These local artifacts should not appear as repository changes.

### Implementation

`.gitignore` excludes `tests/test_db.sqlite*`.

## Validation

- `uv run pytest -q` — 1 passed, 1 integration module skipped as intended
- `uv run ruff check src tests` — passed
- `uv run ruff format --check src tests` — passed
- `markdownlint --config /Users/mmassari/.markdownlint.json README.md` — passed
- `git diff --check` — passed